### PR TITLE
Potential fix for code scanning alert no. 7: Stored cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"tailwind-merge": "^3.1.0",
 		"tailwindcss-animate": "^1.0.7",
 		"unified": "^11.0.5",
-		"unist-util-visit": "^5.0.0"
+		"unist-util-visit": "^5.0.0",
+		"escape-html": "^1.0.3"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.51.1",

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -3,7 +3,7 @@ import Footer from '@/components/footer';
 import Breadcrumb from '@/components/breadcrumb';
 import { getAllPosts, PostMetadata } from '@/lib/posts'; // Import from lib/posts
 import Link from 'next/link';
-// Removed unused notFound import
+import escapeHtml from 'escape-html';
 import { Metadata } from 'next'; // Removed unused ResolvingMetadata
 import { siteMetadataConfig } from '@/lib/metadata.config'; // Import the config
 
@@ -77,7 +77,7 @@ export default async function TagPage(props: { params: Promise<{ tag: string }> 
 									>
 										{' '}
 										{/* Use slug for key */}
-										<Link href={`/blog/${post.slug}`}>
+										<Link href={`/blog/${escapeHtml(post.slug)}`}>
 											{' '}
 											{/* Use slug for link */}
 											<h3 className="hover:text-primary/80 dark:hover:text-primary/80 mb-2 text-xl font-bold transition-colors">


### PR DESCRIPTION
Potential fix for [https://github.com/nightconcept/nextjs-solivan-dev-v3/security/code-scanning/7](https://github.com/nightconcept/nextjs-solivan-dev-v3/security/code-scanning/7)

To fix the problem, we need to sanitize the `slug` value before using it in the HTML output. This can be done by using a library like `escape-html` to escape any potentially harmful characters in the `slug`. This will ensure that any HTML tags or scripts in the `slug` are rendered harmless.

- In `src/app/tags/[tag]/page.tsx`, we need to import the `escape-html` library and use it to sanitize the `slug` value before using it in the `Link` component.
- We will add the necessary import for `escape-html` and update the code where the `slug` is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
